### PR TITLE
Replace binary assets with SVG placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# gptposter# gptposter
+# Chandigarh Dinbhar Poster Studio
+
+A Hostinger-ready PHP 8.x web application for generating private newsroom posters (1080×1350) with auto-rotating advertisements and multiple layout presets.
+
+## Features
+
+- **Authentication** – Password-protected access backed by bcrypt hashes (`users.php`). Default account: `editor` / `newsroom123`.
+- **Canvas designer** – Pure HTML5 canvas rendering driven by vanilla JavaScript with six poster layouts (Classic, Compact, Magazine, Overlay, Two-column, Two Photos).
+- **Ad rotation** – Locked top/bottom ad slots that rotate through paired creatives after every successful export, persisted via filesystem state.
+- **Fixed masthead** – Same-origin SVG masthead bundled with the repo to avoid CORS issues during exports while keeping the repo binary-free.
+- **Hindi-friendly typography** – Interface and poster fonts prefer common Devanagari families; body copy is rendered with custom justification logic.
+- **Exports & logging** – One-click PNG/JPG download buttons plus CSV logging of username, timestamp (IST), IP and layout for each export.
+- **Footer automation** – Footer automatically shows site URL, India Standard Time stamp, and the signed-in user.
+- **Hostinger compatible** – No database required; uses PHP sessions and filesystem storage only.
+
+## Project structure
+
+```
+assets/            Masthead + ad slot SVG artwork (same-origin)
+data/              Runtime files (ad index, export logs)
+lib/ads.php        Helper functions for ad rotation persistence
+index.php          Login screen
+poster.php         Authenticated poster builder
+log_export.php     Export logger + ad rotation endpoint
+scripts.js         Canvas rendering + UI interactions
+styles.css         Application styling
+users.php          Bcrypt hashed credentials
+```
+
+## Setup
+
+1. Deploy the repository to a PHP 8.x environment (e.g., Hostinger shared hosting).
+2. Ensure the `data/` directory is writable by PHP for export logging and ad rotation.
+3. Update `users.php` with newsroom-specific usernames and bcrypt hashes if needed.
+4. Optionally replace the bundled masthead or ad creatives inside `assets/` with newsroom artwork. Provide SVG (or other text-based) assets with the same filenames to keep exports canvas-safe without adding binary files.
+5. Visit the site, sign in with a configured user, and start designing posters.
+
+## Usage notes
+
+- Export buttons trigger both the canvas download and a server-side log entry. Ads rotate automatically after each logged export.
+- Poster body copy is justified using a custom line-spacing algorithm to keep Hindi text neat.
+- The secondary photo input is only used by the “Two Photos” layout; other layouts ignore it.
+- All time stamps are generated in IST to match the footer requirement.
+
+## Security
+
+- Sessions protect authenticated routes; unauthenticated access to `poster.php` or `log_export.php` is blocked.
+- Credentials are never stored in plaintext. To add users, generate a hash via `password_hash('new-password', PASSWORD_BCRYPT)` and update `users.php`.
+
+## Development
+
+- Run `php -l <file>` to lint PHP sources.
+- Canvas logic lives in `scripts.js` and uses no external dependencies.

--- a/assets/ads/bottom1.svg
+++ b/assets/ads/bottom1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="120" viewBox="0 0 1080 120">
+  <rect width="1080" height="120" fill="#f9a825" rx="20" />
+  <text x="540" y="72" text-anchor="middle" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="42" fill="#1b1f2d" font-weight="700">
+    नीचे का विज्ञापन 1 • आज ही ऑर्डर करें
+  </text>
+</svg>

--- a/assets/ads/bottom2.svg
+++ b/assets/ads/bottom2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="120" viewBox="0 0 1080 120">
+  <rect width="1080" height="120" fill="#ffca28" rx="20" />
+  <text x="540" y="72" text-anchor="middle" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="42" fill="#4e342e" font-weight="700">
+    नीचे का विज्ञापन 2 • परिवार के साथ भोजन
+  </text>
+</svg>

--- a/assets/ads/bottom3.svg
+++ b/assets/ads/bottom3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="120" viewBox="0 0 1080 120">
+  <rect width="1080" height="120" fill="#8d6e63" rx="20" />
+  <text x="540" y="72" text-anchor="middle" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="42" fill="#ffecb3" font-weight="700">
+    नीचे का विज्ञापन 3 • गृह सजावट ऑफर
+  </text>
+</svg>

--- a/assets/ads/top1.svg
+++ b/assets/ads/top1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="120" viewBox="0 0 1080 120">
+  <rect width="1080" height="120" fill="#ff7043" rx="20" />
+  <text x="540" y="72" text-anchor="middle" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="44" fill="#ffffff" font-weight="700">
+    शीर्ष विज्ञापन 1 • लोकल मार्केट सेल
+  </text>
+</svg>

--- a/assets/ads/top2.svg
+++ b/assets/ads/top2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="120" viewBox="0 0 1080 120">
+  <rect width="1080" height="120" fill="#26a69a" rx="20" />
+  <text x="540" y="72" text-anchor="middle" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="44" fill="#ffffff" font-weight="700">
+    शीर्ष विज्ञापन 2 • हेल्थ चेकअप कैंप
+  </text>
+</svg>

--- a/assets/ads/top3.svg
+++ b/assets/ads/top3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="120" viewBox="0 0 1080 120">
+  <rect width="1080" height="120" fill="#ab47bc" rx="20" />
+  <text x="540" y="72" text-anchor="middle" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="44" fill="#f3e5f5" font-weight="700">
+    शीर्ष विज्ञापन 3 • एजुकेशन फेयर
+  </text>
+</svg>

--- a/assets/masthead.svg
+++ b/assets/masthead.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="180" viewBox="0 0 1080 180">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0d47a1" />
+      <stop offset="100%" stop-color="#1976d2" />
+    </linearGradient>
+  </defs>
+  <rect width="1080" height="180" fill="url(#bg)" />
+  <text x="72" y="108" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="72" font-weight="700" fill="#ffffff">
+    चंडीगढ़ दिनभर
+  </text>
+  <text x="72" y="150" font-family="'Noto Sans Devanagari', 'Mukta', 'Mangal', sans-serif" font-size="32" fill="#bbdefb">
+    Chandigarh Dinbhar News Network
+  </text>
+</svg>

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,3 @@
+# Runtime generated files
+exports.csv
+ad_index.json

--- a/data/ad_pairs.php
+++ b/data/ad_pairs.php
@@ -1,0 +1,15 @@
+<?php
+return [
+    [
+        'top' => 'assets/ads/top1.svg',
+        'bottom' => 'assets/ads/bottom1.svg',
+    ],
+    [
+        'top' => 'assets/ads/top2.svg',
+        'bottom' => 'assets/ads/bottom2.svg',
+    ],
+    [
+        'top' => 'assets/ads/top3.svg',
+        'bottom' => 'assets/ads/bottom3.svg',
+    ],
+];

--- a/index.php
+++ b/index.php
@@ -1,0 +1,52 @@
+<?php
+session_start();
+
+if (isset($_SESSION['username'])) {
+    header('Location: poster.php');
+    exit;
+}
+
+$users = include __DIR__ . '/users.php';
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($username !== '' && isset($users[$username]) && password_verify($password, $users[$username])) {
+        session_regenerate_id(true);
+        $_SESSION['username'] = $username;
+        header('Location: poster.php');
+        exit;
+    }
+
+    $error = 'Invalid username or password.';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Poster Studio Login</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="auth-page">
+    <main class="auth-card">
+        <h1>Chandigarh Dinbhar Poster Studio</h1>
+        <p class="auth-lead">Private newsroom tool for generating Hostinger-ready news posters.</p>
+        <?php if ($error !== ''): ?>
+            <div class="alert" role="alert"><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
+        <?php endif; ?>
+        <form method="post" class="auth-form" autocomplete="off">
+            <label for="username">Username</label>
+            <input type="text" id="username" name="username" required autofocus>
+
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required>
+
+            <button type="submit" class="primary-button">Sign in</button>
+        </form>
+    </main>
+</body>
+</html>

--- a/lib/ads.php
+++ b/lib/ads.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * @return array<int, array{top: string, bottom: string}>
+ */
+function getAdPairs(): array
+{
+    $pairs = include __DIR__ . '/../data/ad_pairs.php';
+    if (!is_array($pairs) || $pairs === []) {
+        throw new RuntimeException('At least one ad pair must be configured.');
+    }
+
+    return $pairs;
+}
+
+function getAdIndexPath(): string
+{
+    return __DIR__ . '/../data/ad_index.json';
+}
+
+function ensureAdIndexFile(): void
+{
+    $path = getAdIndexPath();
+    if (!file_exists($path)) {
+        $directory = dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+        file_put_contents($path, json_encode(['index' => 0], JSON_PRETTY_PRINT));
+    }
+}
+
+function readAdIndex(): int
+{
+    $pairs = getAdPairs();
+    $count = count($pairs);
+    if ($count === 0) {
+        return 0;
+    }
+
+    ensureAdIndexFile();
+    $path = getAdIndexPath();
+    $handle = fopen($path, 'c+');
+    if ($handle === false) {
+        return 0;
+    }
+
+    try {
+        if (!flock($handle, LOCK_SH)) {
+            return 0;
+        }
+        rewind($handle);
+        $contents = stream_get_contents($handle) ?: '';
+        flock($handle, LOCK_UN);
+    } finally {
+        fclose($handle);
+    }
+
+    $data = json_decode($contents, true);
+    $index = is_array($data) && isset($data['index']) ? (int) $data['index'] : 0;
+
+    if ($index < 0 || $index >= $count) {
+        $index = 0;
+    }
+
+    return $index;
+}
+
+/**
+ * @return array{top: string, bottom: string}
+ */
+function getCurrentAdPair(): array
+{
+    $pairs = getAdPairs();
+    $index = readAdIndex();
+
+    return $pairs[$index % count($pairs)];
+}
+
+/**
+ * Advances the ad index and returns the next pair.
+ *
+ * @return array{top: string, bottom: string}
+ */
+function advanceAdIndex(): array
+{
+    $pairs = getAdPairs();
+    $count = count($pairs);
+    if ($count === 0) {
+        return ['top' => '', 'bottom' => ''];
+    }
+
+    ensureAdIndexFile();
+    $path = getAdIndexPath();
+    $handle = fopen($path, 'c+');
+    if ($handle === false) {
+        return $pairs[0];
+    }
+
+    $nextPair = $pairs[0];
+    try {
+        if (!flock($handle, LOCK_EX)) {
+            return $nextPair;
+        }
+        rewind($handle);
+        $contents = stream_get_contents($handle) ?: '';
+        $data = json_decode($contents, true);
+        $current = is_array($data) && isset($data['index']) ? (int) $data['index'] : 0;
+        $next = ($current + 1) % $count;
+        $nextPair = $pairs[$next];
+
+        ftruncate($handle, 0);
+        rewind($handle);
+        fwrite($handle, json_encode(['index' => $next], JSON_PRETTY_PRINT));
+        fflush($handle);
+        flock($handle, LOCK_UN);
+    } finally {
+        fclose($handle);
+    }
+
+    return $nextPair;
+}

--- a/log_export.php
+++ b/log_export.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['username'])) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Authentication required']);
+    exit;
+}
+
+$input = file_get_contents('php://input');
+$data = json_decode($input ?? '', true);
+
+if (!is_array($data)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid payload']);
+    exit;
+}
+
+$design = isset($data['design']) ? (string) $data['design'] : '';
+$format = isset($data['format']) ? (string) $data['format'] : '';
+
+$allowedDesigns = ['classic', 'compact', 'magazine', 'overlay', 'two_column', 'two_photos'];
+$allowedFormats = ['png', 'jpeg'];
+
+if ($design === '' || !in_array($design, $allowedDesigns, true)) {
+    http_response_code(422);
+    echo json_encode(['error' => 'Unknown design']);
+    exit;
+}
+
+if ($format === '' || !in_array($format, $allowedFormats, true)) {
+    http_response_code(422);
+    echo json_encode(['error' => 'Unknown export format']);
+    exit;
+}
+
+require_once __DIR__ . '/lib/ads.php';
+
+$exportDir = __DIR__ . '/data';
+if (!is_dir($exportDir)) {
+    mkdir($exportDir, 0775, true);
+}
+
+$logPath = $exportDir . '/exports.csv';
+$needsHeader = !file_exists($logPath);
+
+$record = [
+    'timestamp' => (new DateTime('now', new DateTimeZone('Asia/Kolkata')))->format('Y-m-d H:i:s'),
+    'username' => $_SESSION['username'],
+    'ip' => $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+    'design' => $design,
+    'format' => $format,
+];
+
+$handle = fopen($logPath, 'a');
+if ($handle === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Unable to write log']);
+    exit;
+}
+
+if (flock($handle, LOCK_EX)) {
+    if ($needsHeader) {
+        fputcsv($handle, array_keys($record));
+    }
+    fputcsv($handle, $record);
+    fflush($handle);
+    flock($handle, LOCK_UN);
+}
+fclose($handle);
+
+try {
+    $nextAds = advanceAdIndex();
+} catch (RuntimeException $exception) {
+    $nextAds = ['top' => '', 'bottom' => ''];
+}
+
+echo json_encode([
+    'success' => true,
+    'message' => 'Export logged. Ads rotated.',
+    'nextAds' => $nextAds,
+]);

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: index.php');
+exit;

--- a/poster.php
+++ b/poster.php
@@ -1,0 +1,125 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['username'])) {
+    header('Location: index.php');
+    exit;
+}
+
+require_once __DIR__ . '/lib/ads.php';
+
+$username = $_SESSION['username'];
+$mastheadPath = 'assets/masthead.svg';
+$currentAds = ['top' => '', 'bottom' => ''];
+
+try {
+    $currentAds = getCurrentAdPair();
+} catch (RuntimeException $exception) {
+    $currentAds = ['top' => '', 'bottom' => ''];
+}
+
+$designOptions = [
+    'classic' => 'Classic',
+    'compact' => 'Compact',
+    'magazine' => 'Magazine',
+    'overlay' => 'Overlay',
+    'two_column' => 'Two-column',
+    'two_photos' => 'Two Photos',
+];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Poster Studio</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="app-shell">
+<header class="app-header">
+    <div>
+        <h1>Poster Studio</h1>
+        <p>Generate share-ready 1080×1350 news posters with auto-rotating ads.</p>
+    </div>
+    <div class="user-badge">
+        <span>Signed in as <strong><?php echo htmlspecialchars($username, ENT_QUOTES, 'UTF-8'); ?></strong></span>
+        <a class="logout-link" href="logout.php">Logout</a>
+    </div>
+</header>
+<main class="app-main">
+    <section class="control-panel" aria-label="Poster controls">
+        <div class="field-group">
+            <label for="designSelect">Design template</label>
+            <select id="designSelect" name="design">
+                <?php foreach ($designOptions as $value => $label): ?>
+                    <option value="<?php echo htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="field-group">
+            <label for="headlineInput">Headline</label>
+            <input type="text" id="headlineInput" maxlength="180" placeholder="मुख्य शीर्षक यहाँ लिखें">
+        </div>
+        <div class="field-group">
+            <label for="summaryInput">Summary / kicker</label>
+            <input type="text" id="summaryInput" maxlength="200" placeholder="मुख्य बिंदु">
+        </div>
+        <div class="field-group">
+            <label for="bodyInput">Body copy</label>
+            <textarea id="bodyInput" rows="8" placeholder="विवरण यहाँ लिखें"></textarea>
+        </div>
+        <div class="field-group">
+            <label for="bylineInput">Reporter &amp; location</label>
+            <input type="text" id="bylineInput" maxlength="120" placeholder="रिपोर्टर • स्थान">
+        </div>
+        <div class="field-group">
+            <label for="primaryPhotoInput">Primary photo</label>
+            <input type="file" id="primaryPhotoInput" accept="image/*">
+        </div>
+        <div class="field-group">
+            <label for="secondaryPhotoInput">Secondary photo (Two Photos)</label>
+            <input type="file" id="secondaryPhotoInput" accept="image/*">
+        </div>
+        <div class="field-pair">
+            <div class="field-group">
+                <label for="backgroundColorInput">Poster background</label>
+                <input type="color" id="backgroundColorInput" value="#ffffff">
+            </div>
+            <div class="field-group">
+                <label for="accentColorInput">Accent color</label>
+                <input type="color" id="accentColorInput" value="#c62828">
+            </div>
+        </div>
+        <div class="actions">
+            <button type="button" class="primary-button export" data-format="png">Export PNG</button>
+            <button type="button" class="secondary-button export" data-format="jpeg">Export JPG</button>
+            <button type="button" class="ghost-button" id="resetButton">Reset</button>
+        </div>
+        <p class="status-text" id="statusText" role="status" aria-live="polite"></p>
+        <div class="ad-preview" aria-live="polite">
+            <h2>Ad slots</h2>
+            <div class="ad-slot">
+                <span>Top</span>
+                <img id="topAdPreview" src="<?php echo htmlspecialchars($currentAds['top'], ENT_QUOTES, 'UTF-8'); ?>" alt="Top ad preview">
+            </div>
+            <div class="ad-slot">
+                <span>Bottom</span>
+                <img id="bottomAdPreview" src="<?php echo htmlspecialchars($currentAds['bottom'], ENT_QUOTES, 'UTF-8'); ?>" alt="Bottom ad preview">
+            </div>
+        </div>
+    </section>
+    <section class="preview-panel" aria-label="Poster preview">
+        <canvas id="posterCanvas" width="1080" height="1350" role="img" aria-label="Poster preview"></canvas>
+    </section>
+</main>
+<script>
+window.posterConfig = {
+    username: <?php echo json_encode($username, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>,
+    masthead: <?php echo json_encode($mastheadPath, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>,
+    ads: <?php echo json_encode($currentAds, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>,
+    designs: <?php echo json_encode($designOptions, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>
+};
+</script>
+<script src="scripts.js"></script>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,826 @@
+(() => {
+  'use strict';
+
+  const config = window.posterConfig || {};
+  const canvas = document.getElementById('posterCanvas');
+  if (!canvas) {
+    return;
+  }
+  const ctx = canvas.getContext('2d');
+  const WIDTH = canvas.width;
+  const HEIGHT = canvas.height;
+  const FONT_FAMILY = '"Noto Sans Devanagari", "Mangal", "Mukta", "Kohinoor Devanagari", sans-serif';
+  const BODY_FONT = FONT_FAMILY;
+  const DEFAULT_HEADLINE = 'अपना समाचार शीर्षक यहाँ लिखें';
+  const DEFAULT_BODY = 'मुख्य समाचार विवरण यहाँ जोड़ा जाएगा। संक्षिप्त बिंदुओं का उपयोग करें ताकि पोस्टर पूरी तरह संतुलित दिखे।';
+  const DEFAULT_SECOND_BODY = 'अतिरिक्त जानकारी के लिए यहाँ पाठ लिखें।';
+  const istFormatter = new Intl.DateTimeFormat('en-IN', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'Asia/Kolkata'
+  });
+
+  const state = {
+    design: 'classic',
+    headline: '',
+    summary: '',
+    body: '',
+    byline: '',
+    username: config.username || 'editor',
+    accentColor: '#c62828',
+    backgroundColor: '#ffffff'
+  };
+
+  const images = {
+    masthead: null,
+    topAd: null,
+    bottomAd: null,
+    primary: null,
+    secondary: null
+  };
+
+  let renderPending = false;
+
+  function requestRender() {
+    if (renderPending) {
+      return;
+    }
+    renderPending = true;
+    window.requestAnimationFrame(() => {
+      renderPending = false;
+      renderPoster();
+    });
+  }
+
+  function loadStaticImage(src, key) {
+    if (!src) {
+      images[key] = null;
+      requestRender();
+      return;
+    }
+    const image = new Image();
+    image.onload = requestRender;
+    image.src = src;
+    if (image.complete) {
+      requestRender();
+    }
+    images[key] = image;
+  }
+
+  loadStaticImage(config.masthead, 'masthead');
+  if (config.ads) {
+    loadStaticImage(config.ads.top, 'topAd');
+    loadStaticImage(config.ads.bottom, 'bottomAd');
+  }
+
+  const controls = {
+    design: document.getElementById('designSelect'),
+    headline: document.getElementById('headlineInput'),
+    summary: document.getElementById('summaryInput'),
+    body: document.getElementById('bodyInput'),
+    byline: document.getElementById('bylineInput'),
+    primaryPhoto: document.getElementById('primaryPhotoInput'),
+    secondaryPhoto: document.getElementById('secondaryPhotoInput'),
+    backgroundColor: document.getElementById('backgroundColorInput'),
+    accentColor: document.getElementById('accentColorInput'),
+    status: document.getElementById('statusText'),
+    reset: document.getElementById('resetButton'),
+    topAdPreview: document.getElementById('topAdPreview'),
+    bottomAdPreview: document.getElementById('bottomAdPreview')
+  };
+
+  if (controls.design) {
+    state.design = controls.design.value;
+    controls.design.addEventListener('change', (event) => {
+      state.design = event.target.value;
+      announceStatus('');
+      requestRender();
+    });
+  }
+
+  if (controls.headline) {
+    state.headline = controls.headline.value;
+    controls.headline.addEventListener('input', (event) => {
+      state.headline = event.target.value;
+      requestRender();
+    });
+  }
+
+  if (controls.summary) {
+    state.summary = controls.summary.value;
+    controls.summary.addEventListener('input', (event) => {
+      state.summary = event.target.value;
+      requestRender();
+    });
+  }
+
+  if (controls.body) {
+    state.body = controls.body.value;
+    controls.body.addEventListener('input', (event) => {
+      state.body = event.target.value;
+      requestRender();
+    });
+  }
+
+  if (controls.byline) {
+    state.byline = controls.byline.value;
+    controls.byline.addEventListener('input', (event) => {
+      state.byline = event.target.value;
+      requestRender();
+    });
+  }
+
+  if (controls.backgroundColor) {
+    state.backgroundColor = controls.backgroundColor.value || state.backgroundColor;
+    controls.backgroundColor.addEventListener('input', (event) => {
+      state.backgroundColor = event.target.value;
+      requestRender();
+    });
+  }
+
+  if (controls.accentColor) {
+    state.accentColor = controls.accentColor.value || state.accentColor;
+    controls.accentColor.addEventListener('input', (event) => {
+      state.accentColor = event.target.value;
+      requestRender();
+    });
+  }
+
+  if (controls.primaryPhoto) {
+    controls.primaryPhoto.addEventListener('change', (event) => {
+      handleImageUpload(event.target.files, 'primary');
+    });
+  }
+
+  if (controls.secondaryPhoto) {
+    controls.secondaryPhoto.addEventListener('change', (event) => {
+      handleImageUpload(event.target.files, 'secondary');
+    });
+  }
+
+  if (controls.reset) {
+    controls.reset.addEventListener('click', () => {
+      if (controls.design) {
+        controls.design.selectedIndex = 0;
+        state.design = controls.design.value;
+      }
+      if (controls.headline) {
+        controls.headline.value = '';
+      }
+      if (controls.summary) {
+        controls.summary.value = '';
+      }
+      if (controls.body) {
+        controls.body.value = '';
+      }
+      if (controls.byline) {
+        controls.byline.value = '';
+      }
+      if (controls.primaryPhoto) {
+        controls.primaryPhoto.value = '';
+      }
+      if (controls.secondaryPhoto) {
+        controls.secondaryPhoto.value = '';
+      }
+      if (controls.backgroundColor) {
+        controls.backgroundColor.value = '#ffffff';
+      }
+      if (controls.accentColor) {
+        controls.accentColor.value = '#c62828';
+      }
+      state.headline = '';
+      state.summary = '';
+      state.body = '';
+      state.byline = '';
+      state.backgroundColor = '#ffffff';
+      state.accentColor = '#c62828';
+      images.primary = null;
+      images.secondary = null;
+      announceStatus('Cleared all fields.');
+      requestRender();
+    });
+  }
+
+  document.querySelectorAll('.export').forEach((button) => {
+    button.addEventListener('click', () => {
+      const format = button.getAttribute('data-format') || 'png';
+      performExport(format);
+    });
+  });
+
+  function announceStatus(message) {
+    if (!controls.status) {
+      return;
+    }
+    controls.status.textContent = message;
+  }
+
+  function handleImageUpload(files, key) {
+    if (!files || files.length === 0) {
+      images[key] = null;
+      requestRender();
+      return;
+    }
+    const file = files[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = requestRender;
+      img.src = reader.result;
+      images[key] = img;
+      if (img.complete) {
+        requestRender();
+      }
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function performExport(format) {
+    const mime = format === 'jpeg' ? 'image/jpeg' : 'image/png';
+    window.requestAnimationFrame(() => {
+      canvas.toBlob((blob) => {
+        if (!blob) {
+          announceStatus('Export failed. Please try again.');
+          return;
+        }
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = `poster-${state.design}-${timestamp}.${format === 'jpeg' ? 'jpg' : 'png'}`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(link.href);
+        announceStatus(`Exported ${format.toUpperCase()} successfully.`);
+        logExport(format).catch(() => {
+          announceStatus('Exported, but logging failed.');
+        });
+      }, mime, format === 'jpeg' ? 0.92 : undefined);
+    });
+  }
+
+  async function logExport(format) {
+    try {
+      const response = await fetch('log_export.php', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          design: state.design,
+          format: format
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error('Request failed');
+      }
+
+      const data = await response.json();
+      if (data && data.nextAds) {
+        updateAds(data.nextAds);
+      }
+      if (data && data.message) {
+        announceStatus(data.message);
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  function updateAds(nextAds) {
+    if (!nextAds) {
+      return;
+    }
+    if (nextAds.top) {
+      loadStaticImage(nextAds.top, 'topAd');
+      if (controls.topAdPreview) {
+        controls.topAdPreview.src = nextAds.top;
+      }
+    }
+    if (nextAds.bottom) {
+      loadStaticImage(nextAds.bottom, 'bottomAd');
+      if (controls.bottomAdPreview) {
+        controls.bottomAdPreview.src = nextAds.bottom;
+      }
+    }
+  }
+
+  function renderPoster() {
+    ctx.save();
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = state.backgroundColor || '#ffffff';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+
+    const mastheadHeight = 180;
+    const adHeight = 120;
+    const topAdY = mastheadHeight;
+    const bottomAdY = HEIGHT - adHeight;
+
+    drawMasthead(mastheadHeight);
+    drawAdSlot(images.topAd, 0, topAdY, WIDTH, adHeight, 'Top Ad');
+    drawAdSlot(images.bottomAd, 0, bottomAdY, WIDTH, adHeight, 'Bottom Ad');
+
+    const marginX = 72;
+    const contentTop = topAdY + adHeight + 36;
+    const footerReserved = 96;
+    const contentBottom = bottomAdY - footerReserved;
+    const layout = {
+      contentX: marginX,
+      contentY: contentTop,
+      contentWidth: WIDTH - marginX * 2,
+      contentBottom: contentBottom,
+      contentHeight: contentBottom - contentTop,
+      bottomAdY: bottomAdY
+    };
+
+    const renderer = DESIGN_RENDERERS[state.design] || renderClassic;
+    renderer(layout);
+
+    drawFooter(bottomAdY);
+
+    ctx.restore();
+  }
+
+  function drawMasthead(height) {
+    ctx.save();
+    if (images.masthead && images.masthead.complete && images.masthead.naturalWidth) {
+      ctx.drawImage(images.masthead, 0, 0, WIDTH, height);
+    } else {
+      ctx.fillStyle = '#0d3a78';
+      ctx.fillRect(0, 0, WIDTH, height);
+      ctx.fillStyle = '#ffffff';
+      ctx.font = `700 ${Math.floor(height * 0.42)}px ${FONT_FAMILY}`;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('Chandigarh Dinbhar', 48, height / 2);
+    }
+    ctx.restore();
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+  }
+
+  function drawAdSlot(image, x, y, width, height, label) {
+    ctx.save();
+    if (image && image.complete && image.naturalWidth) {
+      ctx.drawImage(image, x, y, width, height);
+    } else {
+      ctx.fillStyle = '#f6f6f6';
+      ctx.fillRect(x, y, width, height);
+      ctx.strokeStyle = hexToRgba(state.accentColor, 0.8);
+      ctx.lineWidth = 4;
+      ctx.setLineDash([14, 10]);
+      ctx.strokeRect(x + 12, y + 12, width - 24, height - 24);
+      ctx.setLineDash([]);
+      ctx.fillStyle = '#666666';
+      ctx.font = `500 ${Math.min(42, height * 0.4)}px ${BODY_FONT}`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(label, x + width / 2, y + height / 2);
+    }
+    ctx.restore();
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+  }
+
+  function drawFooter(bottomAdY) {
+    const footerText = `www.chandigarhdinbhar.in • ${formatIST()} • Made by: ${state.username}`;
+    ctx.save();
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const fontSize = 32;
+    ctx.font = `500 ${fontSize}px ${BODY_FONT}`;
+    const textWidth = ctx.measureText(footerText).width;
+    const paddingX = 24;
+    const width = Math.min(textWidth + paddingX * 2, WIDTH - 80);
+    const height = fontSize * 1.8;
+    const centerX = WIDTH / 2;
+    const centerY = bottomAdY - height / 2 - 8;
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.88)';
+    ctx.fillRect(centerX - width / 2, centerY - height / 2, width, height);
+    ctx.fillStyle = '#1f1f1f';
+    ctx.fillText(footerText, centerX, centerY);
+    ctx.restore();
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+  }
+
+  function formatIST() {
+    return istFormatter.format(new Date());
+  }
+
+  function drawHeadlineBlock(layout) {
+    let cursorY = layout.contentY;
+    const kicker = (state.summary || '').trim();
+    if (kicker) {
+      ctx.fillStyle = state.accentColor;
+      const kickerSize = 36;
+      ctx.font = `600 ${kickerSize}px ${BODY_FONT}`;
+      cursorY = drawWrappedText(kicker, layout.contentX, cursorY, layout.contentWidth, kickerSize * 1.2);
+      cursorY += 12;
+    }
+    const headlineText = (state.headline || '').trim() || DEFAULT_HEADLINE;
+    const baseSize = 82;
+    const headlineSize = adjustFontSize(headlineText, layout.contentWidth, baseSize, 48, '700');
+    ctx.fillStyle = '#121212';
+    ctx.font = `700 ${headlineSize}px ${FONT_FAMILY}`;
+    cursorY = drawWrappedText(headlineText, layout.contentX, cursorY, layout.contentWidth, headlineSize * 1.05);
+    return cursorY;
+  }
+
+  function adjustFontSize(text, maxWidth, baseSize, minSize, weight) {
+    const words = (text || '').split(/\s+/).filter(Boolean);
+    let size = baseSize;
+    if (words.length === 0) {
+      ctx.font = `${weight} ${baseSize}px ${FONT_FAMILY}`;
+      return baseSize;
+    }
+    while (size > minSize) {
+      ctx.font = `${weight} ${size}px ${FONT_FAMILY}`;
+      const tooWide = words.some((word) => ctx.measureText(word).width > maxWidth);
+      if (!tooWide) {
+        break;
+      }
+      size -= 2;
+    }
+    size = Math.max(size, minSize);
+    ctx.font = `${weight} ${size}px ${FONT_FAMILY}`;
+    return size;
+  }
+
+  function drawWrappedText(text, x, y, maxWidth, lineHeight) {
+    const paragraphs = (text || '').split(/\n+/);
+    let cursorY = y;
+    paragraphs.forEach((paragraph, index) => {
+      const words = paragraph.trim().split(/\s+/).filter(Boolean);
+      if (words.length === 0) {
+        cursorY += lineHeight;
+        return;
+      }
+      let line = '';
+      words.forEach((word) => {
+        const testLine = line ? `${line} ${word}` : word;
+        if (ctx.measureText(testLine).width > maxWidth && line) {
+          ctx.fillText(line, x, cursorY);
+          line = word;
+          cursorY += lineHeight;
+        } else {
+          line = testLine;
+        }
+      });
+      if (line) {
+        ctx.fillText(line, x, cursorY);
+        cursorY += lineHeight;
+      }
+      if (index < paragraphs.length - 1) {
+        cursorY += lineHeight * 0.6;
+      }
+    });
+    return cursorY;
+  }
+
+  function drawByline(x, y) {
+    const bylineText = (state.byline || '').trim();
+    if (!bylineText) {
+      return y;
+    }
+    const size = 32;
+    ctx.fillStyle = hexToRgba(state.accentColor, 0.9);
+    ctx.font = `600 ${size}px ${BODY_FONT}`;
+    ctx.fillText(bylineText, x, y);
+    return y + size * 1.4;
+  }
+
+  function computePhotoLayout(layout, headerBottom, fraction, minHeight, reservedSpace) {
+    const photoY = headerBottom + 3;
+    const available = layout.contentBottom - photoY;
+    if (available <= 180) {
+      return { y: photoY, height: Math.max(available - 40, 160) };
+    }
+    const min = minHeight || 240;
+    const reserved = reservedSpace || 160;
+    let height = Math.min(layout.contentHeight * fraction, 540);
+    if (!Number.isFinite(height) || height < min) {
+      height = Math.min(available - reserved, Math.max(min, available * 0.55));
+    }
+    if (!Number.isFinite(height) || height <= 0) {
+      height = Math.max(available - reserved, min);
+    }
+    if (height > available - 80) {
+      height = Math.max(min, available - 80);
+    }
+    if (height < min) {
+      height = Math.min(min, available - 60);
+    }
+    if (!Number.isFinite(height) || height <= 0) {
+      height = Math.max(available * 0.7, 200);
+    }
+    height = Math.max(160, Math.min(height, available - 40));
+    return { y: photoY, height: height };
+  }
+
+  function drawPrimaryPhoto(x, y, width, height, placeholderLabel) {
+    if (height <= 0) {
+      return y;
+    }
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(x, y, width, height);
+    ctx.clip();
+    if (images.primary && images.primary.complete && images.primary.naturalWidth) {
+      drawImageCover(images.primary, x, y, width, height);
+    } else {
+      drawPhotoPlaceholder(x, y, width, height, placeholderLabel);
+    }
+    ctx.restore();
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    return y + height;
+  }
+
+  function drawSecondaryPhoto(x, y, width, height, placeholderLabel) {
+    if (height <= 0) {
+      return y;
+    }
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(x, y, width, height);
+    ctx.clip();
+    if (images.secondary && images.secondary.complete && images.secondary.naturalWidth) {
+      drawImageCover(images.secondary, x, y, width, height);
+    } else {
+      drawPhotoPlaceholder(x, y, width, height, placeholderLabel);
+    }
+    ctx.restore();
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    return y + height;
+  }
+
+  function drawPhotoPlaceholder(x, y, width, height, label) {
+    ctx.fillStyle = '#f2f2f2';
+    ctx.fillRect(x, y, width, height);
+    ctx.strokeStyle = hexToRgba(state.accentColor, 0.8);
+    ctx.lineWidth = 4;
+    ctx.setLineDash([16, 12]);
+    ctx.strokeRect(x + 10, y + 10, width - 20, height - 20);
+    ctx.setLineDash([]);
+    ctx.fillStyle = '#666666';
+    const fontSize = Math.max(28, Math.min(width, height) * 0.06);
+    ctx.font = `500 ${fontSize}px ${BODY_FONT}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(label, x + width / 2, y + height / 2);
+  }
+
+  function drawImageCover(image, x, y, width, height) {
+    const imgWidth = image.naturalWidth || image.width;
+    const imgHeight = image.naturalHeight || image.height;
+    const imageRatio = imgWidth / imgHeight;
+    const targetRatio = width / height;
+    let sx = 0;
+    let sy = 0;
+    let sWidth = imgWidth;
+    let sHeight = imgHeight;
+
+    if (imageRatio > targetRatio) {
+      sHeight = imgHeight;
+      sWidth = sHeight * targetRatio;
+      sx = (imgWidth - sWidth) / 2;
+    } else {
+      sWidth = imgWidth;
+      sHeight = sWidth / targetRatio;
+      sy = (imgHeight - sHeight) / 2;
+    }
+
+    ctx.drawImage(image, sx, sy, sWidth, sHeight, x, y, width, height);
+  }
+
+  function drawJustifiedText(text, x, y, maxWidth, lineHeight, options) {
+    const maxHeight = options && typeof options.maxHeight === 'number' ? options.maxHeight : Infinity;
+    const maxY = y + maxHeight;
+    const paragraphs = (text || '').split(/\n+/);
+    const spaceWidth = ctx.measureText(' ').width || 4;
+    let cursorY = y;
+
+    for (let pIndex = 0; pIndex < paragraphs.length; pIndex += 1) {
+      const paragraph = paragraphs[pIndex].trim();
+      if (paragraph.length === 0) {
+        if (cursorY + lineHeight > maxY) {
+          const remainderParas = paragraphs.slice(pIndex + 1);
+          return { y: cursorY, remainder: remainderParas.join('\n').trim() };
+        }
+        cursorY += lineHeight;
+        continue;
+      }
+
+      const words = paragraph.split(/\s+/);
+      let lineWords = [];
+      let lineWidth = 0;
+
+      for (let wIndex = 0; wIndex < words.length; wIndex += 1) {
+        const word = words[wIndex];
+        const wordWidth = ctx.measureText(word).width;
+        if (lineWords.length === 0) {
+          lineWords.push(word);
+          lineWidth = wordWidth;
+          continue;
+        }
+        const projectedWidth = lineWidth + spaceWidth + wordWidth;
+        if (projectedWidth > maxWidth) {
+          if (cursorY + lineHeight > maxY) {
+            const remainderParagraph = lineWords.concat(words.slice(wIndex)).join(' ');
+            const remainder = [remainderParagraph].concat(paragraphs.slice(pIndex + 1)).join('\n');
+            return { y: cursorY, remainder: remainder.trim() };
+          }
+          drawJustifiedLine(lineWords, x, cursorY, maxWidth, spaceWidth, false);
+          cursorY += lineHeight;
+          lineWords = [word];
+          lineWidth = wordWidth;
+        } else {
+          lineWords.push(word);
+          lineWidth = projectedWidth;
+        }
+      }
+
+      if (lineWords.length > 0) {
+        if (cursorY + lineHeight > maxY) {
+          const remainder = [lineWords.join(' ')].concat(paragraphs.slice(pIndex + 1)).join('\n');
+          return { y: cursorY, remainder: remainder.trim() };
+        }
+        drawJustifiedLine(lineWords, x, cursorY, maxWidth, spaceWidth, true);
+        cursorY += lineHeight;
+      }
+
+      if (pIndex < paragraphs.length - 1) {
+        if (cursorY + lineHeight * 0.6 > maxY) {
+          const remainder = paragraphs.slice(pIndex + 1).join('\n');
+          return { y: cursorY, remainder: remainder.trim() };
+        }
+        cursorY += lineHeight * 0.6;
+      }
+    }
+
+    return { y: cursorY, remainder: '' };
+  }
+
+  function drawJustifiedLine(words, x, y, maxWidth, spaceWidth, isLastLine) {
+    if (words.length <= 1 || isLastLine) {
+      ctx.fillText(words.join(' '), x, y);
+      return;
+    }
+    const totalWordsWidth = words.reduce((sum, word) => sum + ctx.measureText(word).width, 0);
+    const gaps = words.length - 1;
+    const gapWidth = gaps > 0 ? (maxWidth - totalWordsWidth) / gaps : spaceWidth;
+    let cursorX = x;
+    words.forEach((word, index) => {
+      ctx.fillText(word, cursorX, y);
+      if (index < words.length - 1) {
+        cursorX += ctx.measureText(word).width + gapWidth;
+      }
+    });
+  }
+
+  function renderClassic(layout) {
+    const headerBottom = drawHeadlineBlock(layout);
+    const photo = computePhotoLayout(layout, headerBottom, 0.52, 260, 160);
+    const photoBottom = drawPrimaryPhoto(layout.contentX, photo.y, layout.contentWidth, photo.height, 'Upload primary photo');
+    let textY = photoBottom + 24;
+    textY = drawByline(layout.contentX, textY);
+    const bodyText = (state.body || '').trim() || DEFAULT_BODY;
+    ctx.fillStyle = '#1b1b1b';
+    const bodySize = 38;
+    ctx.font = `400 ${bodySize}px ${BODY_FONT}`;
+    drawJustifiedText(bodyText, layout.contentX, textY, layout.contentWidth, bodySize * 1.45, { maxHeight: layout.contentBottom - textY });
+  }
+
+  function renderCompact(layout) {
+    const headerBottom = drawHeadlineBlock(layout);
+    const photo = computePhotoLayout(layout, headerBottom, 0.42, 220, 140);
+    const photoBottom = drawPrimaryPhoto(layout.contentX, photo.y, layout.contentWidth, photo.height, 'Upload primary photo');
+    let cardY = photoBottom + 20;
+    let cardHeight = layout.contentBottom - cardY;
+    if (cardHeight < 160) {
+      cardHeight = 160;
+    }
+    ctx.save();
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
+    ctx.fillRect(layout.contentX, cardY, layout.contentWidth, cardHeight);
+    ctx.restore();
+    let textY = cardY + 24;
+    textY = drawByline(layout.contentX + 24, textY);
+    const bodyText = (state.body || '').trim() || DEFAULT_BODY;
+    ctx.fillStyle = '#1d1d1d';
+    const bodySize = 34;
+    ctx.font = `400 ${bodySize}px ${BODY_FONT}`;
+    drawJustifiedText(bodyText, layout.contentX + 24, textY, layout.contentWidth - 48, bodySize * 1.4, { maxHeight: cardHeight - (textY - cardY) - 24 });
+  }
+
+  function renderMagazine(layout) {
+    const headerBottom = drawHeadlineBlock(layout);
+    const photo = computePhotoLayout(layout, headerBottom, 0.6, 260, 160);
+    const photoBottom = drawPrimaryPhoto(layout.contentX, photo.y, layout.contentWidth, photo.height, 'Upload primary photo');
+    const overlayHeight = Math.min(150, photo.height * 0.32);
+    ctx.save();
+    ctx.fillStyle = hexToRgba(state.accentColor, 0.82);
+    ctx.fillRect(layout.contentX, photoBottom - overlayHeight, layout.contentWidth, overlayHeight);
+    ctx.fillStyle = '#ffffff';
+    const overlayFont = Math.max(34, overlayHeight * 0.35);
+    ctx.font = `600 ${overlayFont}px ${BODY_FONT}`;
+    drawWrappedText((state.summary || '').trim() || 'प्रमुख बिंदु यहाँ जाएँ', layout.contentX + 24, photoBottom - overlayHeight + 16, layout.contentWidth - 48, overlayFont * 1.15);
+    ctx.restore();
+    let textY = photoBottom + 24;
+    textY = drawByline(layout.contentX, textY);
+    const bodyText = (state.body || '').trim() || DEFAULT_BODY;
+    ctx.fillStyle = '#1b1b1b';
+    const bodySize = 36;
+    ctx.font = `400 ${bodySize}px ${BODY_FONT}`;
+    drawJustifiedText(bodyText, layout.contentX, textY, layout.contentWidth, bodySize * 1.45, { maxHeight: layout.contentBottom - textY });
+  }
+
+  function renderOverlay(layout) {
+    const headerBottom = drawHeadlineBlock(layout);
+    const photo = computePhotoLayout(layout, headerBottom, 0.68, 260, 120);
+    const photoBottom = drawPrimaryPhoto(layout.contentX, photo.y, layout.contentWidth, photo.height, 'Upload primary photo');
+    ctx.save();
+    ctx.fillStyle = hexToRgba('#000000', 0.35);
+    ctx.fillRect(layout.contentX, photo.y, layout.contentWidth, photo.height);
+    const overlayPadding = 36;
+    ctx.fillStyle = '#ffffff';
+    const bodySize = 36;
+    ctx.font = `400 ${bodySize}px ${BODY_FONT}`;
+    drawJustifiedText((state.body || '').trim() || DEFAULT_BODY, layout.contentX + overlayPadding, photo.y + overlayPadding, layout.contentWidth - overlayPadding * 2, bodySize * 1.4, { maxHeight: photo.height - overlayPadding * 2 });
+    ctx.restore();
+    let textY = photoBottom + 18;
+    textY = drawByline(layout.contentX, textY);
+  }
+
+  function renderTwoColumn(layout) {
+    const headerBottom = drawHeadlineBlock(layout);
+    const photo = computePhotoLayout(layout, headerBottom, 0.48, 240, 160);
+    const photoBottom = drawPrimaryPhoto(layout.contentX, photo.y, layout.contentWidth, photo.height, 'Upload primary photo');
+    let textY = photoBottom + 24;
+    textY = drawByline(layout.contentX, textY);
+    const columnGap = 42;
+    const columnWidth = (layout.contentWidth - columnGap) / 2;
+    const bodyText = (state.body || '').trim() || DEFAULT_BODY;
+    ctx.fillStyle = '#1d1d1d';
+    const bodySize = 34;
+    ctx.font = `400 ${bodySize}px ${BODY_FONT}`;
+    const maxHeight = layout.contentBottom - textY;
+    const first = drawJustifiedText(bodyText, layout.contentX, textY, columnWidth, bodySize * 1.4, { maxHeight: maxHeight });
+    if (first.remainder) {
+      drawJustifiedText(first.remainder, layout.contentX + columnWidth + columnGap, textY, columnWidth, bodySize * 1.4, { maxHeight: maxHeight });
+    }
+  }
+
+  function renderTwoPhotos(layout) {
+    const headerBottom = drawHeadlineBlock(layout);
+    const primaryLayout = computePhotoLayout(layout, headerBottom, 0.4, 220, 220);
+    const firstBottom = drawPrimaryPhoto(layout.contentX, primaryLayout.y, layout.contentWidth, primaryLayout.height, 'Upload primary photo');
+    const secondY = firstBottom + 12;
+    const remaining = layout.contentBottom - secondY;
+    const secondHeight = Math.max(200, Math.min(remaining * 0.5, 420));
+    const secondBottom = drawSecondaryPhoto(layout.contentX, secondY, layout.contentWidth, secondHeight, 'Upload secondary photo');
+    let textY = secondBottom + 20;
+    textY = drawByline(layout.contentX, textY);
+    const bodyText = (state.body || '').trim() || DEFAULT_SECOND_BODY;
+    ctx.fillStyle = '#202020';
+    const bodySize = 34;
+    ctx.font = `400 ${bodySize}px ${BODY_FONT}`;
+    drawJustifiedText(bodyText, layout.contentX, textY, layout.contentWidth, bodySize * 1.45, { maxHeight: layout.contentBottom - textY });
+  }
+
+  const DESIGN_RENDERERS = {
+    classic: renderClassic,
+    compact: renderCompact,
+    magazine: renderMagazine,
+    overlay: renderOverlay,
+    two_column: renderTwoColumn,
+    two_photos: renderTwoPhotos
+  };
+
+  function hexToRgba(hex, alpha) {
+    if (!hex) {
+      return `rgba(0, 0, 0, ${alpha})`;
+    }
+    let value = hex.replace('#', '');
+    if (value.length === 3) {
+      value = value.split('').map((char) => char + char).join('');
+    }
+    const intValue = parseInt(value, 16);
+    const r = (intValue >> 16) & 255;
+    const g = (intValue >> 8) & 255;
+    const b = intValue & 255;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  requestRender();
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(requestRender).catch(() => {
+      requestRender();
+    });
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,335 @@
+:root {
+  --surface: #ffffff;
+  --surface-muted: #f5f7fb;
+  --border: #d9dde5;
+  --text: #1b1f2d;
+  --accent: #c62828;
+  --accent-light: #f7e7e7;
+  --shadow: 0 14px 28px rgba(18, 24, 40, 0.08);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background: var(--surface-muted);
+  color: var(--text);
+  font-family: "Noto Sans Devanagari", "Mangal", "Mukta", "Kohinoor Devanagari", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.auth-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+}
+
+.auth-card {
+  background: var(--surface);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  max-width: 420px;
+  width: 100%;
+  padding: 2.75rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.auth-lead {
+  margin: 0;
+  color: #4f566b;
+  font-size: 1rem;
+}
+
+.alert {
+  background: var(--accent-light);
+  border-left: 4px solid var(--accent);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  color: #7b1021;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-form label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.auth-form input {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+  background: var(--accent);
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(198, 40, 40, 0.25);
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.ghost-button:hover {
+  transform: translateY(-1px);
+}
+
+.secondary-button {
+  background: #1b1f2d;
+  color: #ffffff;
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.75rem 3vw;
+  gap: 1rem;
+}
+
+.app-header h1 {
+  margin: 0 0 0.2rem;
+  font-size: 2rem;
+}
+
+.app-header p {
+  margin: 0;
+  color: #5c6277;
+}
+
+.user-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.logout-link {
+  font-weight: 600;
+}
+
+.app-main {
+  display: flex;
+  gap: 2rem;
+  padding: 0 3vw 3vw;
+  flex: 1;
+}
+
+.control-panel {
+  background: var(--surface);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: calc(100vh - 7rem);
+  overflow-y: auto;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.field-group label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field-group input[type="text"],
+.field-group input[type="file"],
+.field-group input[type="color"],
+.field-group textarea,
+.field-group select {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: #fff;
+}
+
+.field-group textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.field-pair {
+  display: flex;
+  gap: 1rem;
+}
+
+.field-pair .field-group {
+  flex: 1;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.status-text {
+  min-height: 1.4rem;
+  font-size: 0.95rem;
+  color: #56607a;
+}
+
+.ad-preview {
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ad-preview h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.ad-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ad-slot span {
+  font-weight: 600;
+  color: #50566b;
+}
+
+.ad-slot img {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #f3f5f7;
+}
+
+.preview-panel {
+  flex: 1;
+  background: var(--surface);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: auto;
+}
+
+#posterCanvas {
+  max-width: 100%;
+  height: auto;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: #fff;
+}
+
+@media (max-width: 1100px) {
+  .app-main {
+    flex-direction: column;
+  }
+
+  .control-panel {
+    width: 100%;
+    max-height: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: #151823;
+    --surface-muted: #0f111a;
+    --border: rgba(255, 255, 255, 0.08);
+    --text: #f1f3f9;
+    --accent-light: rgba(198, 40, 40, 0.18);
+    --shadow: 0 14px 28px rgba(5, 6, 12, 0.55);
+  }
+
+  body {
+    background: var(--surface-muted);
+    color: var(--text);
+  }
+
+  .control-panel,
+  .preview-panel,
+  .auth-card {
+    background: rgba(21, 24, 35, 0.92);
+    backdrop-filter: blur(10px);
+  }
+
+  .field-group input[type="text"],
+  .field-group input[type="file"],
+  .field-group input[type="color"],
+  .field-group textarea,
+  .field-group select {
+    background: rgba(15, 17, 26, 0.9);
+    color: var(--text);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  #posterCanvas {
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .status-text {
+    color: rgba(255, 255, 255, 0.7);
+  }
+}

--- a/users.php
+++ b/users.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'editor' => '$2y$12$oM.iq2FzPqEXbZ7GWPRXlO2HxuGti4K2lr9TZgLcO/CJnCXsGulIG',
+];


### PR DESCRIPTION
## Summary
- add a password-protected poster builder with masthead, ad previews, and export controls
- implement canvas rendering for six layouts with ad rotation logging and IST footer automation
- swap bundled masthead/advert creatives to same-origin SVG placeholders and document the binary-free requirement

## Testing
- php -l index.php
- php -l poster.php
- php -l log_export.php
- php -l lib/ads.php
- php -l logout.php
- php -l data/ad_pairs.php

------
https://chatgpt.com/codex/tasks/task_e_68cffba79140832792c7561e0c080a3c